### PR TITLE
add prev and next page to list of always-rendered pages

### DIFF
--- a/LogPaginationFactory.php
+++ b/LogPaginationFactory.php
@@ -43,8 +43,10 @@
 		$min	= min($current, $min);
 		$max	= max($current, $max);
 		$total	= $max - $min + 1;
-		$head	= $current - $min;	// number of pages before the current page
-		$tail	= $max - $current;	// number of pages after the current page
+		$head	= $current - $min;			// number of pages before the current page
+		$tail	= $max - $current;			// number of pages after the current page
+		$prev	= max(1, $current-1);		// previous page (or page 1)
+		$next	= min($max, $current +1);	// next page (or last page)
 
 		if ($total <= $steps) {
 			/* we have less pages in our list than the maximal number of steps.
@@ -53,8 +55,8 @@
 			$elements = range($min, $max);
 		} else {
 
-			// the first, the last and the current page belong to the pagination in any case
-			$elements	= array_unique(array((int) $current, (int) $min, (int) $max));
+			// the first, the last, the current, next and prev page belong to the pagination in any case
+			$elements	= array_unique(array((int) $current, (int) $min, (int) $max, (int) $prev, (int) $next));
 			$steps		-= count($elements);
 			
 			if ($steps > 0) {


### PR DESCRIPTION
Like discussed, add prev and next page to list of always-rendered pages. Tested with the mb3 implementation.
